### PR TITLE
Introduce stellar state interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v1.3.9 - dev
+
+- Add stellar state interface.
+
 ## v1.3.8 - 2026-08-04
 
 - Normalize indexed operations to `apply!(state, indices, operation)` and support

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gabs"
 uuid = "0eb812ee-a11f-4f5e-b8d4-bb8a44f06f50"
 authors = ["Andrew Kille"]
-version = "1.3.8"
+version = "1.3.9-dev"
 
 [workspace]
 projects = ["test", "test/projects/jet"]

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -488,3 +488,194 @@ issymplectic(QuadBlockBasis(1), S, atol = 1e-12)
 ```
 In the last line of code, we used the symplectic check [`issymplectic`](@ref). In general, we can
 check if a state or operator is Gaussian with [`isgaussian`](@ref).
+
+## Stellar States
+
+Every Gaussian state is pure or mixed, but no Gaussian state exhibits negativity in its Wigner function. To describe pure non-Gaussian states while keeping the phase space formalism, Gabs provides the [`StellarState`](@ref) type, which stores a state in the form $|\psi\rangle = \hat{U}|C\rangle$, where $\hat{U}$ is a Gaussian unitary and $|C\rangle$ is a normalized superposition of Fock states with finite support.
+
+```@docs; canonical = false
+StellarState
+```
+
+The core is stored as an array with one index per mode, so the amplitude of $|k_1, \ldots, k_N\rangle$ sits at `core[k₁+1, …, k_N+1]`. The Gaussian factor is a [`GaussianUnitary`](@ref), and it supplies the symplectic basis and the `ħ` convention of the stellar state, so `x.basis` and `x.ħ` are forwarded to it.
+
+The following predefined functions are supported for creating `StellarState` objects:
+- [`fockstate`](@ref)
+- [`randstellar`](@ref)
+
+A Fock state is an elementary case, with an identity Gaussian factor and a core supported on a single multi-index:
+
+```jldoctest
+julia> fockstate(QuadPairBasis(1), 2)
+StellarState for 1 mode.
+  symplectic basis: QuadPairBasis
+  stellar rank: 2
+core: 3-element Vector{ComplexF64}:
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 1.0 + 0.0im
+displacement: 2-element Vector{Float64}:
+ 0.0
+ 0.0
+symplectic: 2×2 Matrix{Float64}:
+ 1.0  0.0
+ 0.0  1.0
+```
+
+As with [`coherentstate`](@ref), a scalar argument is applied to every mode, while a vector assigns an occupation to each mode individually:
+
+```jldoctest
+julia> basis = QuadPairBasis(3);
+
+julia> stellarrank(fockstate(basis, 2))
+6
+
+julia> stellarrank(fockstate(basis, [1, 0, 2]))
+3
+```
+
+In this formalism, photon addition and subtraction both reduce to a single question: what does a ladder
+operator become when it is pushed through the Gaussian factor? For a Gaussian
+unitary characterized by displacement vector $\mathbf{d}$, symplectic matrix $\mathbf{S}$,
+and mode operators $\hat{a}_j = (\hat{x}_j + i \hat{p}_j)/\sqrt{2\hbar}$, we have the
+transformation
+
+```math
+\hat{U}^{\dagger} \hat{a}_j^{\dagger} \hat{U} = \sum_{k} \left( \mu_{jk} \hat{a}_k^{\dagger} + \nu_{jk} \hat{a}_k \right) + \gamma_j,
+```
+
+where $\boldsymbol{\mu}$ and $\boldsymbol{\nu}$ are built from the four blocks of
+$\mathbf{S}$ and $\boldsymbol{\gamma}$ from $\mathbf{d}$, in the same convention
+$\hat{U}^{\dagger} \hat{\boldsymbol{\xi}} \hat{U} = \mathbf{S} \hat{\boldsymbol{\xi}} + \mathbf{d}$
+that [`GaussianUnitary`](@ref) stores. Symplecticity of $\mathbf{S}$ is equivalent to the
+relations $\boldsymbol{\mu}\boldsymbol{\mu}^{\dagger} - \boldsymbol{\nu}\boldsymbol{\nu}^{\dagger} = \mathbf{I}$
+and $\boldsymbol{\mu}\boldsymbol{\nu}^{\text{T}} = \boldsymbol{\nu}\boldsymbol{\mu}^{\text{T}}$
+being satisfied, the first of which shows that $\boldsymbol{\mu}$ is invertible. The
+Gaussian factor is passive when $\boldsymbol{\nu} = 0$.
+
+Its a fun little exercise to check the above formula against your favorite unitary and see how the machinery works. Take, for example the definitions in [`squeeze`](@ref) or [`displace`](@ref).
+
+!!! note
+    The decomposition $|\psi\rangle = \hat{U}|C\rangle$ is not unique. For any passive unitary $\hat{V}$, the pair $(\hat{V}|C\rangle, \hat{U}\hat{V}^{\dagger})$ describes the same state, since passive unitaries are the ones that preserve finite Fock support. Thus equality and `Base.isapprox` for `StellarState` compare the stored core and Gaussian factor, not the states they represent.
+
+### Stellar Rank
+
+The stellar rank $r$ of $|\psi\rangle = \hat{U}|C\rangle$ is the total degree of the core, i.e. the largest $|\mathbf{k}| = k_1 + \cdots + k_N$ carrying a nonzero amplitude. It is computed with [`stellarrank`](@ref). Two properties make it the natural measure of non-Gaussianity in this setting: it is invariant under every Gaussian unitary, and it vanishes exactly on the pure Gaussian states.
+
+```jldoctest
+julia> basis = QuadPairBasis(1); x = fockstate(basis, 1);
+
+julia> stellarrank(squeeze(basis, 1.0, pi/4) * x)
+1
+
+julia> isgaussian(x)
+false
+
+julia> isgaussian(fockstate(basis, 0))
+true
+```
+
+Hence, Gabs uses the following rules for type conversion. A pure [`GaussianState`](@ref) becomes a rank-zero stellar state whose Gaussian factor is the positive symmetric symplectic square root of $(2/\hbar)\mathbf{V}$, and a rank-zero stellar state becomes the Gaussian state obtained by applying its Gaussian factor to the vacuum:
+
+```jldoctest
+julia> basis = QuadPairBasis(1);
+
+julia> x = StellarState(squeezedstate(basis, 0.5, pi/4));
+
+julia> stellarrank(x)
+0
+
+julia> GaussianState(x) ≈ squeezedstate(basis, 0.5, pi/4)
+true
+```
+
+Conversion in either direction throws when the hypothesis fails: `StellarState` requires the Gaussian state to be pure, and `GaussianState` requires the stellar rank to vanish.
+
+Actions of Gaussian unitaries are called with `*` and [`apply!`](@ref), exactly as for Gaussian states, and act on the Gaussian factor alone while leaving the core untouched. Tensor products, [`embed`](@ref), and [`changebasis`](@ref) are likewise supported, and the rank is additive under `⊗`:
+
+```jldoctest
+julia> basis = QuadPairBasis(1);
+
+julia> fockstate(basis, 1) ⊗ fockstate(basis, 2) ≈ fockstate(QuadPairBasis(2), [1, 2])
+true
+
+julia> stellarrank(fockstate(basis, 1) ⊗ fockstate(basis, 2))
+3
+```
+
+!!! note
+    [`ptrace`](@ref) is not defined for stellar states. Discarding a mode of an entangled pure state produces a mixed state, which admits no decomposition of the form $\hat{U}|C\rangle$. For the same reason [`purity`](@ref) returns `1` and [`entropy_vn`](@ref) returns `0` for every `StellarState`.
+
+### Photon Addition and Subtraction
+
+Normalized photon addition and subtraction on a chosen mode are provided by [`addphoton`](@ref) and [`subtractphoton`](@ref). Both leave the Gaussian factor untouched and push the ladder operator through it, so the core absorbs $\hat{U}^{\dagger} \hat{a}_i^{\dagger} \hat{U}$ or $\hat{U}^{\dagger} \hat{a}_i \hat{U}$, whose coefficients are the $i$-th rows of the Bogoliubov equation written above.
+
+```jldoctest
+julia> basis = QuadPairBasis(1); vac = fockstate(basis, 0);
+
+julia> addphoton(vac) ≈ fockstate(basis, 1)
+true
+
+julia> stellarrank(addphoton(addphoton(vac)))
+2
+```
+
+Addition raises the rank by exactly one, since the top-degree part of the core is multiplied by the linear form $\sum_k \mu_{ik} z_k$, which is nonzero because $\boldsymbol{\mu}$ is invertible. Subtraction is not symmetric with it, and its effect on the rank is governed by row $i$ of $\boldsymbol{\nu}$ and by $\gamma_i$:
+
+| Gaussian factor at mode `index` | example | rank of `subtractphoton(x)` |
+| :---: | :---: | :---: |
+| $\nu_{i\cdot} \neq 0$ | squeezed vacuum | $r+1$ |
+| $\nu_{i\cdot} = 0$, $\gamma_i \neq 0$ | displaced Fock state | $r$ |
+| $\nu_{i\cdot} = 0$, $\gamma_i = 0$ | Fock state | $r-1$ |
+
+```jldoctest
+julia> basis = QuadPairBasis(1); vac = fockstate(basis, 0);
+
+julia> stellarrank(subtractphoton(squeeze(basis, 1.0, 0.0) * vac))
+1
+
+julia> stellarrank(subtractphoton(displace(basis, 1.0+im) * fockstate(basis, 1)))
+1
+
+julia> stellarrank(subtractphoton(fockstate(basis, 1)))
+0
+```
+
+The middle row is the statement that a coherent state is an eigenstate of the annihilation operator. That is, subtraction returns the same state up to normalization, and the rank is unchanged. The last row is the only case in which the core can shrink, and subtraction throws when it would annihilate the state, as for $\hat{a}|0\rangle$.
+
+### The Stellar Function
+
+The stellar (also called Bargmann), function of a state with Fock amplitudes $\psi_{\mathbf{k}}$ is
+
+```math
+F_{\psi}(\mathbf{z}) = \sum_{\mathbf{k}} \psi_{\mathbf{k}} \frac{\mathbf{z}^{\mathbf{k}}}{\sqrt{\mathbf{k}!}}, \quad \text{where} \quad \mathbf{z}^{\mathbf{k}} = \prod_j z_j^{k_j}, \quad \mathbf{k}! = \prod_j k_j!,
+```
+
+and is evaluated with [`stellarfunction`](@ref).
+
+```@docs; canonical = false
+stellarfunction
+```
+
+For a stellar state the sum has a closed form. Pushing the core through the Gaussian factor gives
+
+```math
+F_{\psi}(\mathbf{z}) = \mathcal{N} \exp\left( \tfrac{1}{2} \mathbf{z}^{\text{T}} \mathbf{\Sigma} \mathbf{z} + \boldsymbol{\tau}^{\text{T}} \mathbf{z} \right) p(\mathbf{z}), \qquad \mathbf{\Sigma} = \bar{\boldsymbol{\nu}} \boldsymbol{\mu}^{-1}, \quad \boldsymbol{\tau} = \bar{\boldsymbol{\gamma}} - \mathbf{\Sigma} \boldsymbol{\gamma},
+```
+
+with $p$ a polynomial of total degree $r$. The Gaussian prefactor never vanishes, so the zeros of $F_{\psi}$ are the zeros of $p$. For a single mode this is the origin of the name: the stellar rank counts the zeros of the stellar function in the complex plane, with multiplicity.
+
+```jldoctest
+julia> basis = QuadPairBasis(1); α = 1.0 + 0.5im;
+
+julia> stellarfunction(displace(basis, α) * fockstate(basis, 0), 0.4 + 0.2im)
+0.6654917625398412 + 0.2813654043279519im
+
+julia> stellarfunction(displace(basis, α) * fockstate(basis, 1), conj(α))
+0.0 + 0.0im
+```
+
+The first state is coherent, with $F(z) = e^{-|\alpha|^2/2 + \alpha z}$, which is nowhere zero and has rank zero. The second is a displaced single-photon state, with $F(z) = (z - \bar{\alpha}) e^{-|\alpha|^2/2 + \alpha z}$, whose single zero sits at $\bar{\alpha}$ and accounts for its rank of one. A squeezed vacuum, $F(z) = e^{-\tanh(r) z^2/2}/\sqrt{\cosh r}$, is again nowhere zero.
+
+!!! note
+    A [`GaussianUnitary`](@ref) records the pair $(\mathbf{d}, \mathbf{S})$ rather than a metaplectic operator, so the Gaussian factor determines $\hat{U}$ only up to a global phase and $F_{\psi}$ is fixed only up to the same phase. The gauge used here is $\mathcal{N} > 0$.

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -477,7 +477,7 @@ blochmessiah
 polar
 ```
 Let's see an example with the Williamson decomposition:
-```@repl; using Gabs
+```@repl
 using Gabs, LinearAlgebra
 state = randstate(QuadBlockBasis(1))
 F = williamson(state)

--- a/ext/QuantumOpticsBaseExt/QuantumOpticsBaseExt.jl
+++ b/ext/QuantumOpticsBaseExt/QuantumOpticsBaseExt.jl
@@ -37,7 +37,7 @@ end
 
 function _vacuum_ket(cutoff::Integer, nmodes::Integer)
     mode_basis = FockBasis(cutoff)
-    vacuum = fockstate(mode_basis, 0)
+    vacuum = QuantumOpticsBase.fockstate(mode_basis, 0)
     return isone(nmodes) ? vacuum : tensor(ntuple(_ -> vacuum, nmodes)...)
 end
 

--- a/src/Gabs.jl
+++ b/src/Gabs.jl
@@ -1,7 +1,7 @@
 module Gabs
 
 import LinearAlgebra
-using LinearAlgebra: I, det, mul!, diag, qr, eigvals, Diagonal, cholesky, Symmetric, dot, Hermitian, logdet, norm
+using LinearAlgebra: I, det, mul!, diag, qr, eigvals, Diagonal, cholesky, Symmetric, dot, Hermitian, logdet
 
 import QuantumInterface: StateVector, AbstractOperator, apply!, tensor, ⊗, directsum, ⊕, entropy_vn, fidelity, logarithmic_negativity, ptrace, embed
 
@@ -73,6 +73,8 @@ include("homodyne.jl")
 include("wigner.jl")
 
 include("metrics.jl")
+
+include("stellar.jl")
 
 include("linearcombinations.jl")
 

--- a/src/Gabs.jl
+++ b/src/Gabs.jl
@@ -1,7 +1,7 @@
 module Gabs
 
 import LinearAlgebra
-using LinearAlgebra: I, det, mul!, diag, qr, eigvals, Diagonal, cholesky, Symmetric, dot, Hermitian, logdet
+using LinearAlgebra: I, det, mul!, diag, qr, eigvals, Diagonal, cholesky, Symmetric, dot, Hermitian, logdet, norm
 
 import QuantumInterface: StateVector, AbstractOperator, apply!, tensor, ⊗, directsum, ⊕, entropy_vn, fidelity, logarithmic_negativity, ptrace, embed
 
@@ -14,6 +14,7 @@ using SymplecticMatrices: williamson, Williamson, polar, Polar, blochmessiah, Bl
 export
     # types
     GaussianState, GaussianUnitary, GaussianChannel, GaussianLinearCombination,
+    StellarState,
     # Gaussian measurements
     generaldyne, Generaldyne, homodyne, Homodyne,
     # symplectic representations
@@ -23,19 +24,22 @@ export
     # predefined Gaussian states
     vacuumstate, thermalstate, coherentstate, squeezedstate, eprstate,
     # non-Gaussian states
-    catstate_even, catstate_odd, catstate, gkpstate,
+    catstate_even, catstate_odd, catstate, gkpstate, fockstate,
+    addphoton, subtractphoton,
     norm_factor,
     # predefined Gaussian channels
     displace, squeeze, twosqueeze, phaseshift, beamsplitter,
     attenuator, amplifier,
     # random objects
-    randstate, randunitary, randchannel, randsymplectic,
+    randstate, randunitary, randchannel, randsymplectic, randstellar,
     # wigner functions
     wigner, wignerchar,
     # symplectic form and checks
     symplecticform, issymplectic, isgaussian, sympspectrum,
     # factorizations
     williamson, Williamson, polar, Polar, blochmessiah, BlochMessiah,
+    # stellar things
+    stellarfunction, stellarrank,
     # metrics
     purity, entropy_vn, fidelity, logarithmic_negativity,
     cross_wigner, cross_wignerchar,

--- a/src/Gabs.jl
+++ b/src/Gabs.jl
@@ -1,7 +1,7 @@
 module Gabs
 
 import LinearAlgebra
-using LinearAlgebra: I, det, mul!, diag, qr, eigvals, Diagonal, cholesky, Symmetric, dot, Hermitian, logdet
+using LinearAlgebra: I, det, mul!, diag, qr, eigvals, Diagonal, cholesky, Symmetric, dot, Hermitian, logdet, eigen
 
 import QuantumInterface: StateVector, AbstractOperator, apply!, tensor, ⊗, directsum, ⊕, entropy_vn, fidelity, logarithmic_negativity, ptrace, embed
 

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -18,6 +18,18 @@ CHANNEL_ERROR = lazy"Either an input matrix is not square or
     2N, a transform matrix of size 2N x 2N, and a noise matrix
     of size 2N x 2N." 
 
+STELLAR_ERROR = lazy"The core tensor must carry one index per mode of the Gaussian factor."
+
+CORE_ERROR = lazy"The core tensor must have at least one nonzero amplitude."
+
+RANK_ERROR = lazy"Only a stellar state of rank zero is a Gaussian state."
+
+STELLAR_PURITY_ERROR = lazy"Only a pure Gaussian state has a stellar decomposition."
+
+STELLAR_PTRACE_ERROR = lazy"The reduction of a stellar state is generally mixed and
+    is not itself a stellar state. Convert to a GaussianState when the rank is zero,
+    or work with the density operator directly."
+
 ACTION_ERROR = lazy"The number of modes for the Gaussian operator
     does not match the number of modes for the Gaussian state, or the symplectic representations for
     the two types are different."

--- a/src/nongaussian_states.jl
+++ b/src/nongaussian_states.jl
@@ -360,31 +360,34 @@ function catstate(basis::SymplecticBasis, αs::AbstractVector, phases::AbstractV
 end
 
 """
-    addphoton(x::StellarState)
+    addphoton(x::StellarState, index::Int = 1)
 
-Normalized single-mode photon addition. The Gaussian factor is unchanged,
-while the core absorbs the Bogoliubov-transformed ladder operator.
+Normalized single-mode photon addition on a particular index of a stellar state. 
+The Gaussian factor is unchanged, while the core absorbs the Bogoliubov-transformed ladder operator.
 """
-function addphoton(x::StellarState{C,G}) where {C,G<:GaussianUnitary{<:SymplecticBasis}}
+function addphoton(x::StellarState, index::Int = 1)
+    1 ≤ index ≤ nmodes(x) || throw(ArgumentError(INDEX_ERROR))
     mu, nu, gamma = _bogoliubov(x.gaussian)
-    return StellarState(_coreaction(x.core, mu, nu, gamma), x.gaussian)
+    return StellarState(_coreaction(x.core, @view(mu[index,:]), @view(nu[index,:]),
+                                    gamma[index]), x.gaussian)
 end
 """
-    subtractphoton(x::StellarState)
+    subtractphoton(x::StellarState, index::Int = 1)
 
-Normalized single-mode photon subtraction. The Gaussian factor is unchanged,
-while the core absorbs the Bogoliubov-transformed ladder operator.
+Normalized single-mode photon subtraction  on a particular index of a stellar state.
+The Gaussian factor is unchanged, while the core absorbs the Bogoliubov-transformed ladder operator.
 """
-function subtractphoton(x::StellarState{C,G}) where {C,G<:GaussianUnitary{<:SymplecticBasis}}
-
+function subtractphoton(x::StellarState, index::Int = 1)
+    1 ≤ index ≤ nmodes(x) || throw(ArgumentError(INDEX_ERROR))
     mu, nu, gamma = _bogoliubov(x.gaussian)
-    return StellarState(_coreaction(x.core, conj(nu), conj(mu), conj(gamma)), x.gaussian)
+    return StellarState(_coreaction(x.core, conj.(@view(nu[index,:])),
+                                    conj.(@view(mu[index,:])), conj(gamma[index])),
+                        x.gaussian)
 end
-
 #=
 With `aⱼ = (qⱼ + i pⱼ)/√(2ħ)`, returns the matrices and vector satisfying
 
-    U† a†ₖ U = Σₖ (μⱼₖ a†ₖ + νⱼₖ aₖ) + γⱼ.
+    U† a†ⱼ U = Σₖ (μⱼₖ a†ₖ + νⱼₖ aₖ) + γⱼ.
 
 Symplecticity is `μμ† - νν† = I`, `μν† = νμ†`, `μ†μ - νᵀν̄ = I`, `μᵀν̄ = ν†μ`.
 =#

--- a/src/nongaussian_states.jl
+++ b/src/nongaussian_states.jl
@@ -358,3 +358,67 @@ function catstate(basis::SymplecticBasis, αs::AbstractVector, phases::AbstractV
     end
     return result
 end
+
+"""
+    addphoton(x::StellarState)
+
+Normalized single-mode photon addition. The Gaussian factor is unchanged,
+while the core absorbs the Bogoliubov-transformed ladder operator.
+"""
+function addphoton(x::StellarState{C,G}) where {C,G<:GaussianUnitary{<:SymplecticBasis}}
+    mu, nu, gamma = _bogoliubov(x.gaussian)
+    return StellarState(_coreaction(x.core, mu, nu, gamma), x.gaussian)
+end
+"""
+    subtractphoton(x::StellarState)
+
+Normalized single-mode photon subtraction. The Gaussian factor is unchanged,
+while the core absorbs the Bogoliubov-transformed ladder operator.
+"""
+function subtractphoton(x::StellarState{C,G}) where {C,G<:GaussianUnitary{<:SymplecticBasis}}
+
+    mu, nu, gamma = _bogoliubov(x.gaussian)
+    return StellarState(_coreaction(x.core, conj(nu), conj(mu), conj(gamma)), x.gaussian)
+end
+
+#=
+With `aⱼ = (qⱼ + i pⱼ)/√(2ħ)`, returns the matrices and vector satisfying
+
+    U† a†ₖ U = Σₖ (μⱼₖ a†ₖ + νⱼₖ aₖ) + γⱼ.
+
+Symplecticity is `μμ† - νν† = I`, `μν† = νμ†`, `μ†μ - νᵀν̄ = I`, `μᵀν̄ = ν†μ`.
+=#
+function _bogoliubov(op::GaussianUnitary{<:QuadBlockBasis,D,S}) where {D,S}
+    n = nmodes(op)
+    d, M = op.disp, op.symplectic
+    A, B = @view(M[1:n, 1:n]), @view(M[1:n, n+1:2n])
+    C, E = @view(M[n+1:2n, 1:n]), @view(M[n+1:2n, n+1:2n])
+    mu = ((A .+ E) .- im .* (C .- B)) ./ 2
+    nu = ((A .- E) .- im .* (C .+ B)) ./ 2
+    gamma = (@view(d[1:n]) .- im .* @view(d[n+1:2n])) ./ sqrt(2*op.ħ)
+    return mu, nu, gamma
+end
+_bogoliubov(op::GaussianUnitary{<:QuadPairBasis,D,S}) where {D,S} =
+    _bogoliubov(changebasis(QuadBlockBasis, op))
+
+# applies Σₖ up[k] a†ₖ + Σₖ down[k] aₖ + shift, then normalizes
+function _coreaction(core::AbstractArray{T,N}, up::AbstractVector,
+                     down::AbstractVector, shift::Number) where {T,N}
+    Tc = complex(float(promote_type(T, eltype(up), eltype(down), typeof(shift))))
+    core′ = zeros(Tc, ntuple(k -> size(core, k) + 1, Val(N)))
+    @inbounds for I in CartesianIndices(core)
+        c = core[I]
+        iszero(c) && continue
+        core′[I] += shift * c
+        for k in Base.OneTo(N)
+            nk = I[k]
+            core′[CartesianIndex(ntuple(l -> l == k ? I[l] + 1 : I[l], Val(N)))] +=
+                up[k] * sqrt(nk) * c
+            nk > 1 && (core′[CartesianIndex(ntuple(l -> l == k ? I[l] - 1 : I[l], Val(N)))] +=
+                down[k] * sqrt(nk - 1) * c)
+        end
+    end
+    nrm = sqrt(sum(abs2, core′))
+    iszero(nrm) && throw(ArgumentError(CORE_ERROR))
+    return _trimcore(core′ ./ nrm)
+end

--- a/src/nongaussian_states.jl
+++ b/src/nongaussian_states.jl
@@ -389,7 +389,7 @@ With `aⱼ = (qⱼ + i pⱼ)/√(2ħ)`, returns the matrices and vector satisfyi
 
     U† a†ⱼ U = Σₖ (μⱼₖ a†ₖ + νⱼₖ aₖ) + γⱼ.
 
-Symplecticity is `μμ† - νν† = I`, `μν† = νμ†`, `μ†μ - νᵀν̄ = I`, `μᵀν̄ = ν†μ`.
+Symplecticity is `μμ† - νν† = I`, `μνᵀ = νμᵀ`, `μ†μ - νᵀν̄ = I`, `μᵀν̄ = ν†μ`.
 =#
 function _bogoliubov(op::GaussianUnitary{<:QuadBlockBasis,D,S}) where {D,S}
     n = nmodes(op)

--- a/src/nongaussian_states.jl
+++ b/src/nongaussian_states.jl
@@ -363,11 +363,6 @@ end
     addphoton(x::StellarState, index::Int = 1)
 
 Normalized photon addition on mode `index` of a stellar state: `a†|ψ⟩/‖a†|ψ⟩‖`.
-The Gaussian factor is unchanged, while the core absorbs `U† a†ᵢ U`, i.e. row `index`
-of `(μ ν)` with constant `γᵢ`.
-
-The rank increases by exactly one: the top-degree part of the core is multiplied by the
-linear form `Σₖ μᵢₖ zₖ`, nonzero because `μ` is invertible.
 """
 function addphoton(x::StellarState, index::Int = 1)
     1 ≤ index ≤ nmodes(x) || throw(ArgumentError(INDEX_ERROR))
@@ -387,13 +382,6 @@ end
     subtractphoton(x::StellarState, index::Int = 1)
 
 Normalized photon subtraction on mode `index` of a stellar state: `a|ψ⟩/‖a|ψ⟩‖`.
-The Gaussian factor is unchanged, while the core absorbs `U† aᵢ U`, which is the adjoint
-of the addition data: the two coefficient blocks exchange and every entry conjugates.
-
-The rank need not increase. The top-degree coefficient is `ν̄ᵢₖ`, so the rank rises by one
-when row `index` of `ν` is nonzero and otherwise falls. For a passive Gaussian factor
-`ν = 0` and this reduces to the annihilation operator on the core; it then throws for the
-vacuum core, where `a|ψ⟩ = 0`.
 """
 function subtractphoton(x::StellarState, index::Int = 1)
     1 ≤ index ≤ nmodes(x) || throw(ArgumentError(INDEX_ERROR))

--- a/src/nongaussian_states.jl
+++ b/src/nongaussian_states.jl
@@ -362,28 +362,53 @@ end
 """
     addphoton(x::StellarState, index::Int = 1)
 
-Normalized single-mode photon addition on a particular index of a stellar state. 
-The Gaussian factor is unchanged, while the core absorbs the Bogoliubov-transformed ladder operator.
+Normalized photon addition on mode `index` of a stellar state: `a†|ψ⟩/‖a†|ψ⟩‖`.
+The Gaussian factor is unchanged, while the core absorbs `U† a†ᵢ U`, i.e. row `index`
+of `(μ ν)` with constant `γᵢ`.
+
+The rank increases by exactly one: the top-degree part of the core is multiplied by the
+linear form `Σₖ μᵢₖ zₖ`, nonzero because `μ` is invertible.
 """
 function addphoton(x::StellarState, index::Int = 1)
     1 ≤ index ≤ nmodes(x) || throw(ArgumentError(INDEX_ERROR))
     mu, nu, gamma = _bogoliubov(x.gaussian)
-    return StellarState(_coreaction(x.core, @view(mu[index,:]), @view(nu[index,:]),
-                                    gamma[index]), x.gaussian)
+    return StellarState(
+        _coreaction(
+            x.core, 
+            @view(mu[index,:]), 
+            @view(nu[index,:]),
+            gamma[index]
+        ), 
+        copy(x.gaussian)
+    )
 end
+
 """
     subtractphoton(x::StellarState, index::Int = 1)
 
-Normalized single-mode photon subtraction  on a particular index of a stellar state.
-The Gaussian factor is unchanged, while the core absorbs the Bogoliubov-transformed ladder operator.
+Normalized photon subtraction on mode `index` of a stellar state: `a|ψ⟩/‖a|ψ⟩‖`.
+The Gaussian factor is unchanged, while the core absorbs `U† aᵢ U`, which is the adjoint
+of the addition data: the two coefficient blocks exchange and every entry conjugates.
+
+The rank need not increase. The top-degree coefficient is `ν̄ᵢₖ`, so the rank rises by one
+when row `index` of `ν` is nonzero and otherwise falls. For a passive Gaussian factor
+`ν = 0` and this reduces to the annihilation operator on the core; it then throws for the
+vacuum core, where `a|ψ⟩ = 0`.
 """
 function subtractphoton(x::StellarState, index::Int = 1)
     1 ≤ index ≤ nmodes(x) || throw(ArgumentError(INDEX_ERROR))
     mu, nu, gamma = _bogoliubov(x.gaussian)
-    return StellarState(_coreaction(x.core, conj.(@view(nu[index,:])),
-                                    conj.(@view(mu[index,:])), conj(gamma[index])),
-                        x.gaussian)
+    return StellarState(
+        _coreaction(
+            x.core, 
+            conj.(@view(nu[index,:])),
+            conj.(@view(mu[index,:])), 
+            conj(gamma[index])
+        ),
+        copy(x.gaussian)
+    )
 end
+
 #=
 With `aⱼ = (qⱼ + i pⱼ)/√(2ħ)`, returns the matrices and vector satisfying
 

--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -130,7 +130,7 @@ randstellar(rng::AbstractRNG, basis::SymplecticBasis{N}, rank::Int; passive = fa
     randstellar(basis, rank; passive = passive, ħ = ħ, rng = rng)
 function _randstellar(rng::AbstractRNG, basis::SymplecticBasis{N}, rank::Int;
                       passive = false, ħ = 2) where {N<:Int}
-    rank ≥ 0 || throw(ArgumentError(RANK_ERROR))
+                      rank ≥ 0 || throw(ArgumentError(lazy"The stellar rank must be a nonnegative integer."))
     n = basis.nmodes
     core = zeros(ComplexF64, ntuple(_ -> rank + 1, n))
     @inbounds for I in CartesianIndices(core)

--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -109,6 +109,51 @@ function _randchannel(rng::AbstractRNG, basis::SymplecticBasis{N}) where {N<:Int
 end
 
 """
+    randstellar([Tc=Array{ComplexF64},] basis::SymplecticBasis, rank::Int;
+                passive=false, ħ=2, rng=Random.default_rng())
+
+Random stellar state of the given rank. Takes the form of a random core 
+supported on multi-indices of total degree at most `rank`, 
+together with `randunitary`.
+"""
+function randstellar(::Type{Tc}, basis::SymplecticBasis{N}, rank::Int;
+                     passive = false, ħ = 2, rng::AbstractRNG = Random.default_rng()) where {Tc,N<:Int}
+    core, op = _randstellar(rng, basis, rank; passive = passive, ħ = ħ)
+    return StellarState(Tc(core), op)
+end
+function randstellar(basis::SymplecticBasis{N}, rank::Int;
+                     passive = false, ħ = 2, rng::AbstractRNG = Random.default_rng()) where {N<:Int}
+    core, op = _randstellar(rng, basis, rank; passive = passive, ħ = ħ)
+    return StellarState(core, op)
+end
+randstellar(rng::AbstractRNG, basis::SymplecticBasis{N}, rank::Int; passive = false, ħ = 2) where {N<:Int} =
+    randstellar(basis, rank; passive = passive, ħ = ħ, rng = rng)
+function _randstellar(rng::AbstractRNG, basis::SymplecticBasis{N}, rank::Int;
+                      passive = false, ħ = 2) where {N<:Int}
+    rank ≥ 0 || throw(ArgumentError(RANK_ERROR))
+    n = basis.nmodes
+    core = zeros(ComplexF64, ntuple(_ -> rank + 1, n))
+    @inbounds for I in CartesianIndices(core)
+        sum(Tuple(I)) - n ≤ rank && (core[I] = randn(rng, ComplexF64))
+    end
+    core ./= sqrt(sum(abs2, core))
+    return _trimcore(core), randunitary(basis; passive = passive, ħ = ħ, rng = rng)
+end
+
+# drop trailing all-zero slices so repeated ladder actions do not inflate the core
+function _trimcore(core::AbstractArray{T,N}) where {T,N}
+    dims = collect(size(core))
+    @inbounds for k in Base.OneTo(N)
+        while dims[k] > 1
+            slice = ntuple(j -> j == k ? (dims[k]:dims[k]) : (1:dims[j]), N)
+            any(!iszero, @view core[slice...]) && break
+            dims[k] -= 1
+        end
+    end
+    return core[ntuple(j -> 1:dims[j], N)...]
+end
+
+"""
     randsymplectic([T=Matrix{Float64},] basis::SymplecticBasis, passive=false, rng=Random.default_rng())
 
 Calculate a random symplectic matrix in symplectic representation defined by `basis`.

--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -128,9 +128,14 @@ function randstellar(basis::SymplecticBasis{N}, rank::Int;
 end
 randstellar(rng::AbstractRNG, basis::SymplecticBasis{N}, rank::Int; passive = false, ħ = 2) where {N<:Int} =
     randstellar(basis, rank; passive = passive, ħ = ħ, rng = rng)
-function _randstellar(rng::AbstractRNG, basis::SymplecticBasis{N}, rank::Int;
-                      passive = false, ħ = 2) where {N<:Int}
-                      rank ≥ 0 || throw(ArgumentError(lazy"The stellar rank must be a nonnegative integer."))
+function _randstellar(
+    rng::AbstractRNG, 
+    basis::SymplecticBasis{N}, 
+    rank::Int;
+    passive = false, 
+    ħ = 2
+) where {N<:Int}
+    rank ≥ 0 || throw(ArgumentError(lazy"The stellar rank must be a nonnegative integer."))
     n = basis.nmodes
     core = zeros(ComplexF64, ntuple(_ -> rank + 1, n))
     @inbounds for I in CartesianIndices(core)

--- a/src/states.jl
+++ b/src/states.jl
@@ -685,6 +685,11 @@ function _ptrace(state::GaussianState{B,M,V}, indices::T) where {B<:QuadBlockBas
     return mean′′, covar′′
 end
 
+ptrace(::StellarState, ::Int) = throw(ArgumentError(STELLAR_PTRACE_ERROR))
+ptrace(::StellarState, ::AbstractVector{<:Int}) = throw(ArgumentError(STELLAR_PTRACE_ERROR))
+ptrace(::Type{Tm}, ::Type{Tc}, ::StellarState, ::Any) where {Tm,Tc} =
+    throw(ArgumentError(STELLAR_PTRACE_ERROR))
+    
 """
     embed(basis::SymplecticBasis, idx::Int, state::GaussianState)
     embed(basis::SymplecticBasis, indices::AbstractVector{<:Int}, state::GaussianState)

--- a/src/states.jl
+++ b/src/states.jl
@@ -689,7 +689,7 @@ ptrace(::StellarState, ::Int) = throw(ArgumentError(STELLAR_PTRACE_ERROR))
 ptrace(::StellarState, ::AbstractVector{<:Int}) = throw(ArgumentError(STELLAR_PTRACE_ERROR))
 ptrace(::Type{Tm}, ::Type{Tc}, ::StellarState, ::Any) where {Tm,Tc} =
     throw(ArgumentError(STELLAR_PTRACE_ERROR))
-    
+
 """
     embed(basis::SymplecticBasis, idx::Int, state::GaussianState)
     embed(basis::SymplecticBasis, indices::AbstractVector{<:Int}, state::GaussianState)
@@ -911,6 +911,8 @@ changebasis(::Type{<:QuadPairBasis}, state::GaussianState{<:QuadPairBasis,M,V}) 
 Change the symplectic basis of a stellar state.
 """
 changebasis(::Type{B1}, x::StellarState) where {B1<:SymplecticBasis} = StellarState(x.core, changebasis(B1, x.gaussian))
+changebasis(::Type{<:QuadPairBasis}, x::StellarState{C,<:GaussianUnitary{<:QuadPairBasis}}) where {C} = x
+changebasis(::Type{<:QuadBlockBasis}, x::StellarState{C,<:GaussianUnitary{<:QuadBlockBasis}}) where {C} = x
 
 """
     sympspectrum(state::GaussianState)

--- a/src/states.jl
+++ b/src/states.jl
@@ -887,7 +887,7 @@ function changebasis(::Type{B1}, state::GaussianState{B2,M,V}) where {B1<:QuadBl
             covar[nmodes + j, nmodes + i] = state.covar[2*j, 2*i]
         end
     end
-    return GaussianState(B1(nmodes), mean, covar)
+    return GaussianState(B1(nmodes), mean, covar; ħ = state.ħ)
 end
 function changebasis(::Type{B1}, state::GaussianState{B2,M,V}) where {B1<:QuadPairBasis,B2<:QuadBlockBasis,M,V}
     nmodes = state.basis.nmodes
@@ -906,7 +906,7 @@ function changebasis(::Type{B1}, state::GaussianState{B2,M,V}) where {B1<:QuadPa
             covar[2*j, 2*i] = state.covar[nmodes + j, nmodes + i]
         end
     end
-    return GaussianState(B1(nmodes), mean, covar)
+    return GaussianState(B1(nmodes), mean, covar; ħ = state.ħ)
 end
 changebasis(::Type{<:QuadBlockBasis}, state::GaussianState{<:QuadBlockBasis,M,V}) where {M,V} = state
 changebasis(::Type{<:QuadPairBasis}, state::GaussianState{<:QuadPairBasis,M,V}) where {M,V} = state

--- a/src/states.jl
+++ b/src/states.jl
@@ -435,7 +435,8 @@ function _fockstate(basis::SymplecticBasis{N}, photons::P; ħ = 2) where {N<:Int
     return _fockstate(basis, fill(photons, basis.nmodes); ħ = ħ)
 end
 function _fockstate(basis::SymplecticBasis{N}, photons::P; ħ = 2) where {N<:Int,P<:AbstractVector}
-    length(photons) == basis.nmodes || throw(DimensionMismatch(STELLAR_ERROR))
+    length(photons) == basis.nmodes || throw(DimensionMismatch(
+        lazy"The occupation vector must carry one entry per mode."))
     dims = Tuple(photons .+ 1)
     core = zeros(ComplexF64, dims)
     core[CartesianIndex(dims)] = one(ComplexF64)

--- a/src/states.jl
+++ b/src/states.jl
@@ -1,5 +1,5 @@
 ##
-# Predefined Gaussian states
+# Predefined Gaussian and non-Gaussian states
 ##
 
 """
@@ -416,6 +416,32 @@ function _eprstate(basis::QuadBlockBasis{N}, r::R, theta::R; ħ = 2) where {N<:I
     return mean, covar
 end
 
+"""
+    fockstate([Tc=Array{ComplexF64}], basis::SymplecticBasis, photons<:Int)
+    fockstate([Tc=Array{ComplexF64}], basis::SymplecticBasis, photons<:AbstractVector)
+
+`StellarState` whose core is a single Fock state and whose Gaussian factor is the identity.
+The stellar rank equals the total photon number.
+"""
+function fockstate(::Type{Tc}, basis::SymplecticBasis{N}, photons::P; ħ = 2) where {Tc,N<:Int,P}
+    core, op = _fockstate(basis, photons; ħ = ħ)
+    return StellarState(Tc(core), op)
+end
+function fockstate(basis::SymplecticBasis{N}, photons::P; ħ = 2) where {N<:Int,P}
+    core, op = _fockstate(basis, photons; ħ = ħ)
+    return StellarState(core, op)
+end
+function _fockstate(basis::SymplecticBasis{N}, photons::P; ħ = 2) where {N<:Int,P<:Int}
+    return _fockstate(basis, fill(photons, basis.nmodes); ħ = ħ)
+end
+function _fockstate(basis::SymplecticBasis{N}, photons::P; ħ = 2) where {N<:Int,P<:AbstractVector}
+    length(photons) == basis.nmodes || throw(DimensionMismatch(STELLAR_ERROR))
+    dims = Tuple(photons .+ 1)
+    core = zeros(ComplexF64, dims)
+    core[CartesianIndex(dims)] = one(ComplexF64)
+    return core, displace(basis, zero(ComplexF64); ħ = ħ)
+end
+
 ##
 # Operations on Gaussian states
 ##
@@ -525,6 +551,23 @@ function _tensor(state1::GaussianState{B1,M1,V1}, state2::GaussianState{B2,M2,V2
     mean′′ = _promote_output_vector(typeof(mean1), typeof(mean2), mean′)
     covar′′ = _promote_output_matrix(typeof(covar1), typeof(covar2), covar′)
     return mean′′, covar′′
+end
+
+"""
+    tensor(state1::StellarState, state2::StellarState)
+
+Tensor product of stellar states, which can also be called with `⊗`.
+"""
+function tensor(state1::StellarState, state2::StellarState)
+    gaussian = state1.gaussian ⊗ state2.gaussian
+    core1, core2 = state1.core, state2.core
+    core = reshape(vec(core1) * transpose(vec(core2)), (size(core1)..., size(core2)...))
+    return StellarState(core, gaussian)
+end
+function tensor(::Type{Tc}, ::Type{Td}, ::Type{Ts}, x::StellarState, y::StellarState) where {Tc,Td,Ts}
+    core1, core2 = x.core, y.core
+    core = reshape(vec(core1) * transpose(vec(core2)), (size(core1)..., size(core2)...))
+    return StellarState(Tc(core), tensor(Td, Ts, x.gaussian, y.gaussian))
 end
 
 """
@@ -751,6 +794,35 @@ function embed(
 end
 
 """
+    embed(basis::SymplecticBasis, idx::Int, state::StellarState)
+    embed(basis::SymplecticBasis, indices::AbstractVector{<:Int}, state::StellarState)
+
+Embed a smaller stellar state into a larger Hilbert space specified by a target
+symplectic basis, inserting it at the mode index (or indices) specified by `idx` or `indices`.
+"""
+function embed(basis::SymplecticBasis, index::Int, x::StellarState)
+    return embed(basis, [index], x)
+end
+function embed(basis::SymplecticBasis, indices::Vector{<:Int}, x::StellarState)
+    @assert length(indices) == nmodes(x) "Number of indices must match number of modes in the state"
+    @assert basis.nmodes ≥ length(indices) "Target basis must be large enough"
+    total = basis.nmodes
+    dims = ones(Int, total)
+    @inbounds for (i, idx) in enumerate(indices)
+        dims[idx] = size(x.core, i)
+    end
+    core = zeros(eltype(x.core), dims...)
+    target = ones(Int, total)
+    @inbounds for I in CartesianIndices(x.core)
+        for (i, idx) in enumerate(indices)
+            target[idx] = I[i]
+        end
+        core[CartesianIndex(target...)] = x.core[I]
+    end
+    return StellarState(core, embed(basis, indices, x.gaussian))
+end
+
+"""
     changebasis(::SymplecticBasis, state::GaussianState)
 
 Change the symplectic basis of a Gaussian state.
@@ -828,6 +900,12 @@ end
 changebasis(::Type{<:QuadBlockBasis}, state::GaussianState{<:QuadBlockBasis,M,V}) where {M,V} = state
 changebasis(::Type{<:QuadPairBasis}, state::GaussianState{<:QuadPairBasis,M,V}) where {M,V} = state
 
+"""
+    changebasis(::SymplecticBasis, state::StellarState)
+
+Change the symplectic basis of a stellar state.
+"""
+changebasis(::Type{B1}, x::StellarState) where {B1<:SymplecticBasis} = StellarState(x.core, changebasis(B1, x.gaussian))
 
 """
     sympspectrum(state::GaussianState)

--- a/src/states.jl
+++ b/src/states.jl
@@ -421,7 +421,10 @@ end
     fockstate([Tc=Array{ComplexF64}], basis::SymplecticBasis, photons<:AbstractVector)
 
 `StellarState` whose core is a single Fock state and whose Gaussian factor is the identity.
-The stellar rank equals the total photon number.
+
+A vector gives the occupation of each mode, so the stellar rank is `sum(photons)`. A scalar
+is broadcast to every mode, as elsewhere in Gabs, so `fockstate(basis, n)` is `|n,…,n⟩` with
+rank `n * basis.nmodes`.
 """
 function fockstate(::Type{Tc}, basis::SymplecticBasis{N}, photons::P; ħ = 2) where {Tc,N<:Int,P}
     core, op = _fockstate(basis, photons; ħ = ħ)
@@ -437,6 +440,8 @@ end
 function _fockstate(basis::SymplecticBasis{N}, photons::P; ħ = 2) where {N<:Int,P<:AbstractVector}
     length(photons) == basis.nmodes || throw(DimensionMismatch(
         lazy"The occupation vector must carry one entry per mode."))
+    all(≥(0), photons) || throw(ArgumentError(
+        lazy"The occupation of each mode must be a nonnegative integer."))
     dims = Tuple(photons .+ 1)
     core = zeros(ComplexF64, dims)
     core[CartesianIndex(dims)] = one(ComplexF64)

--- a/src/stellar.jl
+++ b/src/stellar.jl
@@ -4,7 +4,7 @@ function _stellargaussian(op::GaussianUnitary)
     tau = conj(gamma) - Sigma * gamma
     n = nmodes(op)
     Vsum = (op.ħ/2) .* (op.symplectic * transpose(op.symplectic) + I)
-    scale = op.ħ^(n/2) * det(Vsum)^(-1/4) * exp(-dot(op.disp, Vsum \ op.disp) / 4)
+    scale = exp((n/2)*log(op.ħ) - logdet(Vsum)/4 - dot(op.disp, Vsum \ op.disp)/4)
     return Sigma, tau, scale
 end
 

--- a/src/stellar.jl
+++ b/src/stellar.jl
@@ -52,10 +52,12 @@ end
 """
     stellarfunction(x::StellarState, z)
 
-Bargmann function `F(z) = Σₖ ψₖ z^k / √(k!)` of a stellar state, evaluated at `z`.
-It factors as `𝒩 exp(½zᵀΣz + τᵀz) p(z)` with `Σ = ν̄μ⁻¹`, `τ = γ̄ - Σγ`, and `p` a
-polynomial of total degree `stellarrank(x)`. The exponential factor has no zeros, so the zeros
-of `F` are the zeros of `p` and are `stellarrank(x)` in number.
+Bargmann function `F(z) = Σₖ ψₖ z^k / √(k!)` of a stellar state, evaluated at `z`, where `k`
+runs over occupation multi-indices, `z^k = ∏ⱼ zⱼ^kⱼ`, and `k! = ∏ⱼ kⱼ!`.
+
+It factors as `𝒩 exp(½zᵀΣz + τᵀz) p(z)` with `Σ = ν̄μ⁻¹`, `τ = γ̄ - Σγ`, and `p` a polynomial
+of total degree exactly `stellarrank(x)`. The exponential factor has no zeros, so the zeros
+of `F` are the zeros of `p`; for one mode that is `stellarrank(x)` points with multiplicity.
 
 `GaussianUnitary` records `(d,S)` and not a metaplectic element, so `F` is fixed only up to
 a global phase. The gauge here is `𝒩 > 0`.

--- a/src/stellar.jl
+++ b/src/stellar.jl
@@ -1,0 +1,79 @@
+function _stellargaussian(op::GaussianUnitary)
+    mu, nu, gamma = _bogoliubov(op)
+    Sigma = conj(nu) / mu
+    tau = conj(gamma) - Sigma * gamma
+    n = nmodes(op)
+    Vsum = (op.ħ/2) .* (op.symplectic * transpose(op.symplectic) + I)
+    scale = op.ħ^(n/2) * det(Vsum)^(-1/4) * exp(-dot(op.disp, Vsum \ op.disp) / 4)
+    return Sigma, tau, scale
+end
+
+# applies 𝒟̃_j = μ⁻¹(z - γ) - νᵀ∇ to a coefficient array
+function _stellarderiv(q::Array{ComplexF64,N}, j::Int, minv, nu, shift) where {N}
+    r = zeros(ComplexF64, size(q))
+    for I in CartesianIndices(q)
+        c = q[I]
+        iszero(c) && continue
+        r[I] += shift[j] * c
+        for k in Base.OneTo(N)
+            r[CartesianIndex(ntuple(l -> l == k ? I[l] + 1 : I[l], Val(N)))] += minv[j,k] * c
+            I[k] > 1 && (r[CartesianIndex(ntuple(l -> l == k ? I[l] - 1 : I[l], Val(N)))] -=
+                nu[k,j] * (I[k] - 1) * c)
+        end
+    end
+    return r
+end
+
+# coefficients of p(z) = F_ψ(z) / G(z), a polynomial of total degree stellarrank(x)
+function _stellarpolynomial(x::StellarState)
+    mu, nu, gamma = _bogoliubov(x.gaussian)
+    n = nmodes(x)
+    minv = inv(mu)
+    shift = -(minv * gamma)
+    deg = stellarrank(x)
+    dims = ntuple(_ -> deg + 1, n)
+    p = zeros(ComplexF64, dims)
+    @inbounds for K in CartesianIndices(x.core)
+        c = x.core[K]
+        iszero(c) && continue
+        q = zeros(ComplexF64, dims)
+        q[ntuple(_ -> 1, n)...] = c
+        for j in Base.OneTo(n), _ in Base.OneTo(K[j]-1)
+            q = _stellarderiv(q, j, minv, nu, shift)
+        end
+        for j in Base.OneTo(n), l in Base.OneTo(K[j]-1)
+            q ./= sqrt(l)
+        end
+        p .+= q
+    end
+    return p
+end
+
+"""
+    stellarfunction(x::StellarState, z)
+
+Bargmann function `F(z) = Σₖ ψₖ z^k / √(k!)` of a stellar state, evaluated at `z`.
+It factors as `𝒩 exp(½zᵀΣz + τᵀz) p(z)` with `Σ = ν̄μ⁻¹`, `τ = γ̄ - Σγ`, and `p` a
+polynomial of total degree `stellarrank(x)`. The exponential factor has no zeros, so the zeros
+of `F` are the zeros of `p` and are `stellarrank(x)` in number.
+
+`GaussianUnitary` records `(d,S)` and not a metaplectic element, so `F` is fixed only up to
+a global phase. The gauge here is `𝒩 > 0`.
+"""
+function stellarfunction(x::StellarState, z::AbstractVector)
+    n = nmodes(x)
+    length(z) == n || throw(DimensionMismatch(STELLAR_ERROR))
+    Sigma, tau, scale = _stellargaussian(x.gaussian)
+    p = _stellarpolynomial(x)
+    val = zero(ComplexF64)
+    @inbounds for I in CartesianIndices(p)
+        c = p[I]
+        iszero(c) && continue
+        for j in Base.OneTo(n)
+            c *= z[j]^(I[j]-1)
+        end
+        val += c
+    end
+    return scale * exp(dot(conj(z), Sigma * z)/2 + dot(conj(tau), z)) * val
+end
+stellarfunction(x::StellarState, z::Number) = stellarfunction(x, [z])

--- a/src/stellar.jl
+++ b/src/stellar.jl
@@ -64,7 +64,8 @@ a global phase. The gauge here is `𝒩 > 0`.
 """
 function stellarfunction(x::StellarState, z::AbstractVector)
     n = nmodes(x)
-    length(z) == n || throw(DimensionMismatch(STELLAR_ERROR))
+    length(z) == n || throw(DimensionMismatch(
+        lazy"The evaluation point must carry one coordinate per mode."))
     Sigma, tau, scale = _stellargaussian(x.gaussian)
     p = _stellarpolynomial(x)
     val = zero(ComplexF64)

--- a/src/stellar.jl
+++ b/src/stellar.jl
@@ -54,13 +54,6 @@ end
 
 Bargmann function `F(z) = Σₖ ψₖ z^k / √(k!)` of a stellar state, evaluated at `z`, where `k`
 runs over occupation multi-indices, `z^k = ∏ⱼ zⱼ^kⱼ`, and `k! = ∏ⱼ kⱼ!`.
-
-It factors as `𝒩 exp(½zᵀΣz + τᵀz) p(z)` with `Σ = ν̄μ⁻¹`, `τ = γ̄ - Σγ`, and `p` a polynomial
-of total degree exactly `stellarrank(x)`. The exponential factor has no zeros, so the zeros
-of `F` are the zeros of `p`; for one mode that is `stellarrank(x)` points with multiplicity.
-
-`GaussianUnitary` records `(d,S)` and not a metaplectic element, so `F` is fixed only up to
-a global phase. The gauge here is `𝒩 > 0`.
 """
 function stellarfunction(x::StellarState, z::AbstractVector)
     n = nmodes(x)

--- a/src/types.jl
+++ b/src/types.jl
@@ -567,10 +567,13 @@ A Gaussian state admits this decomposition exactly when it is pure, and `(2/ħ)V
 symplectic exactly then, so the square root is symplectic whenever it exists.
 """
 function StellarState(x::GaussianState; atol::Real = 1e-8)
-    isapprox(purity(x), 1.0; atol = atol) || throw(ArgumentError(STELLAR_PURITY_ERROR))
+    G = sqrt(Symmetric((2/x.ħ) .* x.covar))
+    eltype(G) <: Real || throw(ArgumentError(STELLAR_PURITY_ERROR))
+    G = Matrix(G)
+    issymplectic(x.basis, G; atol = atol, rtol = atol) ||
+        throw(ArgumentError(STELLAR_PURITY_ERROR))
     n = x.basis.nmodes
     core = fill(one(ComplexF64), ntuple(_ -> 1, n))
-    G = Matrix(sqrt(Symmetric((2/x.ħ) .* x.covar)))
     return StellarState(core, GaussianUnitary(x.basis, x.mean, G; ħ = x.ħ))
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -568,14 +568,13 @@ construction; the mean supplies `d`. Inverse of `GaussianState(::StellarState)`.
 A Gaussian state admits this decomposition exactly when it is pure, and `(2/ħ)V` is
 symplectic exactly then, so the square root is symplectic whenever it exists.
 """
-function StellarState(x::GaussianState; atol::Real = 1e-8)
-    G = sqrt(Symmetric((2/x.ħ) .* x.covar))
-    eltype(G) <: Real || throw(ArgumentError(STELLAR_PURITY_ERROR))
-    G = Matrix(G)
+function StellarState(x::GaussianState{B,M,V}; atol::Real = 1e-8) where {B,M,V}
+    F = eigen(Symmetric((2/x.ħ) .* x.covar))
+    all(≥(0), F.values) || throw(ArgumentError(STELLAR_PURITY_ERROR))
+    G = F.vectors * Diagonal(sqrt.(F.values)) * transpose(F.vectors)
     issymplectic(x.basis, G; atol = atol, rtol = atol) ||
         throw(ArgumentError(STELLAR_PURITY_ERROR))
-    n = x.basis.nmodes
-    core = fill(one(ComplexF64), ntuple(_ -> 1, n))
+    core = fill(one(ComplexF64), ntuple(_ -> 1, Val(nmodes(x.basis))))
     return StellarState(core, GaussianUnitary(x.basis, x.mean, G; ħ = x.ħ))
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -432,7 +432,7 @@ symplectic: 2×2 Matrix{Float64}:
  0.0  1.0
 ```
 """
-@kwdef struct StellarState{C,G<:GaussianUnitary} <: StateVector{C,G}
+struct StellarState{C,G<:GaussianUnitary} <: StateVector{C,G}
     core::C
     gaussian::G
     function StellarState(c::C, g::G) where {C,G<:GaussianUnitary}

--- a/src/types.jl
+++ b/src/types.jl
@@ -570,7 +570,9 @@ symplectic exactly then, so the square root is symplectic whenever it exists.
 """
 function StellarState(x::GaussianState{B,M,V}; atol::Real = 1e-8) where {B,M,V}
     F = eigen(Symmetric((2/x.ħ) .* x.covar))
-    all(≥(0), F.values) || throw(ArgumentError(STELLAR_PURITY_ERROR))
+    all(>(0), F.values) || throw(ArgumentError(
+        lazy"The covariance matrix is not positive definite, so its symmetric square root
+        does not exist."))
     G = F.vectors * Diagonal(sqrt.(F.values)) * transpose(F.vectors)
     issymplectic(x.basis, G; atol = atol, rtol = atol) ||
         throw(ArgumentError(STELLAR_PURITY_ERROR))

--- a/src/types.jl
+++ b/src/types.jl
@@ -446,7 +446,9 @@ function Base.getproperty(x::StellarState, s::Symbol)
 end
 Base.propertynames(::StellarState) = (:basis, :core, :gaussian, :ħ)
 Base.:(==)(x::StellarState, y::StellarState) = x.core == y.core && x.gaussian == y.gaussian
-Base.isapprox(x::StellarState, y::StellarState; kwargs...) = isapprox(x.core, y.core; kwargs...) && isapprox(x.gaussian, y.gaussian; kwargs...)
+Base.isapprox(x::StellarState, y::StellarState; kwargs...) =
+    size(x.core) == size(y.core) && isapprox(x.core, y.core; kwargs...) &&
+    isapprox(x.gaussian, y.gaussian; kwargs...)
 Base.copy(x::StellarState) = StellarState(copy(x.core), copy(x.gaussian))
 nmodes(x::StellarState) = nmodes(x.gaussian)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -408,11 +408,6 @@ A stellar state of rank `r` is `|ψ⟩ = U|C⟩`, where `U` is a Gaussian unitar
 multi-indices `k = (k₁,…,kₙ)`, of total degree `r`. The rank `r` is invariant under
 every Gaussian unitary and vanishes exactly on the pure Gaussian states.
 
-The decomposition is not unique: `(|C⟩, U) → (V|C⟩, U V†)` for any passive `V` denotes
-the same ray, since only passive unitaries preserve finite Fock support. 
-Therefore, in Gabs, equality of `StellarState` objects is equality of the stored data, 
-not of the states.
-
 ## Example
 
 ```jldoctest

--- a/src/types.jl
+++ b/src/types.jl
@@ -580,8 +580,8 @@ function StellarState(x::GaussianState{B,M,V}; atol::Real = 1e-8) where {B,M,V}
     return StellarState(core, GaussianUnitary(x.basis, copy(x.mean), G; ħ = x.ħ))
 end
 
-purity(::StellarState) = 1.0
-entropy_vn(::StellarState) = 0.0
+purity(x::StellarState) = one(real(eltype(x.core)))
+entropy_vn(x::StellarState) = zero(real(eltype(x.core)))
 
 """
     isgaussian(x::GaussianState)

--- a/src/types.jl
+++ b/src/types.jl
@@ -576,8 +576,8 @@ function StellarState(x::GaussianState{B,M,V}; atol::Real = 1e-8) where {B,M,V}
     G = F.vectors * Diagonal(sqrt.(F.values)) * transpose(F.vectors)
     issymplectic(x.basis, G; atol = atol, rtol = atol) ||
         throw(ArgumentError(STELLAR_PURITY_ERROR))
-    core = fill(one(ComplexF64), ntuple(_ -> 1, Val(nmodes(x.basis))))
-    return StellarState(core, GaussianUnitary(x.basis, x.mean, G; ħ = x.ħ))
+    core = fill(one(ComplexF64), ntuple(_ -> 1, nmodes(x.basis)))
+    return StellarState(core, GaussianUnitary(x.basis, copy(x.mean), G; ħ = x.ħ))
 end
 
 purity(::StellarState) = 1.0

--- a/src/types.jl
+++ b/src/types.jl
@@ -497,7 +497,7 @@ function apply!(state::StellarState{C,G}, indices::AbstractVector{<:Int}, op::Ga
         quad_indices[2k-1] = 2i - 1
         quad_indices[2k]   = 2i
     end
-    return _applygaussian!(state, op, quad_indices)
+    return _applygaussian!(state, quad_indices, op)
 end
 function apply!(state::StellarState{C,G}, indices::AbstractVector{<:Int}, op::GaussianUnitary) where {C,G<:GaussianUnitary{<:QuadBlockBasis}}
     typeof(op.basis) == typeof(state.basis) || throw(DimensionMismatch(ACTION_ERROR))
@@ -509,7 +509,7 @@ function apply!(state::StellarState{C,G}, indices::AbstractVector{<:Int}, op::Ga
         quad_indices[k]   = i
         quad_indices[k+l] = i + state.basis.nmodes
     end
-    return _applygaussian!(state, op, quad_indices)
+    return _applygaussian!(state, quad_indices, op)
 end
 function _applygaussian!(state::StellarState, quad_indices::Vector{Int}, op::GaussianUnitary)
     d, S = op.disp, op.symplectic
@@ -557,18 +557,21 @@ function GaussianState(x::StellarState)
     return x.gaussian * vacuumstate(x.basis; ħ = x.ħ)
 end
 """
-    StellarState(x::GaussianState)
+    StellarState(x::GaussianState; atol = 1e-8)
 
-Rank-zero stellar state of a pure Gaussian state. The Williamson symplectic factor supplies
-`S` with `V = (ħ/2)SSᵀ` and the mean supplies `d`; the pair is the inverse of
-`GaussianState(::StellarState)`.
+Rank-zero stellar state of a pure Gaussian state. The Gaussian factor is the positive
+symmetric symplectic square root of `(2/ħ)V`, which satisfies `V = (ħ/2)GGᵀ` by
+construction; the mean supplies `d`. Inverse of `GaussianState(::StellarState)`.
+
+A Gaussian state admits this decomposition exactly when it is pure, and `(2/ħ)V` is
+symplectic exactly then, so the square root is symplectic whenever it exists.
 """
 function StellarState(x::GaussianState; atol::Real = 1e-8)
-    F = williamson(x)
-    all(v -> isapprox(v, x.ħ/2; atol = atol), F.spectrum) || throw(ArgumentError(STELLAR_PURITY_ERROR))
+    isapprox(purity(x), 1.0; atol = atol) || throw(ArgumentError(STELLAR_PURITY_ERROR))
     n = x.basis.nmodes
     core = fill(one(ComplexF64), ntuple(_ -> 1, n))
-    return StellarState(core, GaussianUnitary(x.basis, x.mean, F.S; ħ = x.ħ))
+    G = Matrix(sqrt(Symmetric((2/x.ħ) .* x.covar)))
+    return StellarState(core, GaussianUnitary(x.basis, x.mean, G; ħ = x.ħ))
 end
 
 purity(::StellarState) = 1.0

--- a/src/types.jl
+++ b/src/types.jl
@@ -105,6 +105,13 @@ end
 Base.copy(x::GaussianUnitary) = GaussianUnitary(x.basis, copy(x.disp), copy(x.symplectic); ħ = x.ħ)
 nmodes(x::GaussianUnitary) = nmodes(x.basis)
 
+function Base.:(*)(op1::GaussianUnitary, op2::GaussianUnitary)
+    op1.basis == op2.basis || throw(DimensionMismatch(ACTION_ERROR))
+    op1.ħ == op2.ħ || throw(ArgumentError(HBAR_ERROR))
+    d1, S1 = op1.disp, op1.symplectic
+    d2, S2 = op2.disp, op2.symplectic
+    return GaussianUnitary(op1.basis, S1 * d2 .+ d1, S1 * S2; ħ = op1.ħ)
+end
 function Base.:(*)(op::GaussianUnitary, state::GaussianState)
     op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
     op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
@@ -279,16 +286,6 @@ function Base.show(io::IO, mime::MIME"text/plain", x::GaussianChannel)
     print(io, "\nnoise: ")
     Base.show(io, mime, x.noise)
 end
-function Base.summary(io::IO, x::Union{GaussianState,GaussianUnitary,GaussianChannel})
-    printstyled(io, nameof(typeof(x)); color=:blue)
-    basis = x.basis
-    modenum = basis.nmodes
-    if isone(modenum)
-        print(io, " for $(modenum) mode.")
-    else
-        print(io, " for $(modenum) modes.")
-    end
-end
 Base.copy(x::GaussianChannel) = GaussianChannel(x.basis, copy(x.disp), copy(x.transform), copy(x.noise); ħ = x.ħ)
 nmodes(x::GaussianChannel) = nmodes(x.basis)
 
@@ -396,6 +393,188 @@ function apply!(
 end
 
 """
+Defines a stellar state for an N-mode bosonic system: a Gaussian unitary applied to a
+core state of finite Fock support.
+
+## Fields
+
+- `core`: Fock amplitude tensor with one index per mode.
+- `gaussian`: The Gaussian unitary factor, which also supplies `basis` and `ħ`.
+
+## Mathematical description of a stellar state
+
+A stellar state of rank `r` is `|ψ⟩ = U|C⟩`, where `U` is a Gaussian unitary and
+`|C⟩ = ∑ₖ c[k] |k⟩` is a normalized superposition of Fock states over occupation
+multi-indices `k = (k₁,…,kₙ)`, of total degree `r`. The rank `r` is invariant under
+every Gaussian unitary and vanishes exactly on the pure Gaussian states.
+
+The decomposition is not unique: `(|C⟩, U) → (V|C⟩, U V†)` for any passive `V` denotes
+the same ray, since only passive unitaries preserve finite Fock support. 
+Therefore, in Gabs, equality of `StellarState` objects is equality of the stored data, 
+not of the states.
+
+## Example
+
+```jldoctest
+julia> fockstate(QuadPairBasis(1), 2)
+StellarState for 1 mode.
+  symplectic basis: QuadPairBasis
+  stellar rank: 2
+core: 3-element Vector{ComplexF64}:
+ 0.0 + 0.0im
+ 0.0 + 0.0im
+ 1.0 + 0.0im
+displacement: 2-element Vector{Float64}:
+ 0.0
+ 0.0
+symplectic: 2×2 Matrix{Float64}:
+ 1.0  0.0
+ 0.0  1.0
+```
+"""
+@kwdef struct StellarState{C,G<:GaussianUnitary} <: StateVector{C,G}
+    core::C
+    gaussian::G
+    function StellarState(c::C, g::G) where {C,G<:GaussianUnitary}
+        ndims(c) == nmodes(g) || throw(DimensionMismatch(STELLAR_ERROR))
+        any(!iszero, c) || throw(ArgumentError(CORE_ERROR))
+        return new{C,G}(c, g)
+    end
+end
+function Base.getproperty(x::StellarState, s::Symbol)
+    return (s === :basis || s === :ħ) ? getproperty(getfield(x, :gaussian), s) : getfield(x, s)
+end
+Base.propertynames(::StellarState) = (:basis, :core, :gaussian, :ħ)
+Base.:(==)(x::StellarState, y::StellarState) = x.core == y.core && x.gaussian == y.gaussian
+Base.isapprox(x::StellarState, y::StellarState; kwargs...) = isapprox(x.core, y.core; kwargs...) && isapprox(x.gaussian, y.gaussian; kwargs...)
+Base.copy(x::StellarState) = StellarState(copy(x.core), copy(x.gaussian))
+nmodes(x::StellarState) = nmodes(x.gaussian)
+
+function Base.show(io::IO, mime::MIME"text/plain", x::StellarState)
+    Base.summary(io, x)
+    print(io, "\n  symplectic basis: ")
+    printstyled(io, "$(nameof(typeof(x.basis)))"; color = :blue)
+    print(io, "\n  stellar rank: ")
+    printstyled(io, "$(stellarrank(x))"; color = :blue)
+    print(io, "\ncore: ")
+    Base.show(io, mime, x.core)
+    print(io, "\ndisplacement: ")
+    Base.show(io, mime, x.gaussian.disp)
+    print(io, "\nsymplectic: ")
+    Base.show(io, mime, x.gaussian.symplectic)
+end
+
+function Base.:(*)(op::GaussianUnitary, state::StellarState)
+    return StellarState(state.core, op * state.gaussian)
+end
+
+"""
+    apply!(state::StellarState, op::GaussianUnitary)
+    apply!(state::StellarState, indices::AbstractVector, op::GaussianUnitary)
+    apply!(state::StellarState, index::Int, op::GaussianUnitary)
+
+In-place application of a Gaussian unitary `op` on a stellar state `state`.
+Specify `indices` to define the subspace of the stellar state for unitary application.
+"""
+function apply!(state::StellarState, op::GaussianUnitary)
+    op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
+    op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
+    d, S = op.disp, op.symplectic
+    g = state.gaussian
+    g.disp .= S * g.disp .+ d
+    g.symplectic .= S * g.symplectic
+    return state
+end
+function apply!(state::StellarState, index::Int, op::GaussianUnitary)
+    return apply!(state, [index], op)
+end
+function apply!(state::StellarState{C,G}, indices::AbstractVector{<:Int}, op::GaussianUnitary) where {C,G<:GaussianUnitary{<:QuadPairBasis}}
+    typeof(op.basis) == typeof(state.basis) || throw(DimensionMismatch(ACTION_ERROR))
+    op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
+    length(indices) ≤ state.basis.nmodes || throw(ArgumentError(INDEX_ERROR))
+    quad_indices = Vector{Int}(undef, 2length(indices))
+    @inbounds for (k, i) in enumerate(indices)
+        quad_indices[2k-1] = 2i - 1
+        quad_indices[2k]   = 2i
+    end
+    return _applygaussian!(state, op, quad_indices)
+end
+function apply!(state::StellarState{C,G}, indices::AbstractVector{<:Int}, op::GaussianUnitary) where {C,G<:GaussianUnitary{<:QuadBlockBasis}}
+    typeof(op.basis) == typeof(state.basis) || throw(DimensionMismatch(ACTION_ERROR))
+    op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
+    length(indices) ≤ state.basis.nmodes || throw(ArgumentError(INDEX_ERROR))
+    l = length(indices)
+    quad_indices = Vector{Int}(undef, 2l)
+    @inbounds for (k, i) in enumerate(indices)
+        quad_indices[k]   = i
+        quad_indices[k+l] = i + state.basis.nmodes
+    end
+    return _applygaussian!(state, op, quad_indices)
+end
+function _applygaussian!(state::StellarState, quad_indices::Vector{Int}, op::GaussianUnitary)
+    d, S = op.disp, op.symplectic
+    g = state.gaussian
+    m = length(quad_indices)
+    n = 2 * state.basis.nmodes
+    disp_sub = @view g.disp[quad_indices]
+    symp_row = @view g.symplectic[quad_indices, :]
+    # single buffer that's reused across the two products
+    buf = similar(g.symplectic, m, n)
+    buf_vec = @view buf[1:m]
+    # d[q] ← S d[q] + d_op
+    mul!(buf_vec, S, disp_sub)
+    disp_sub .= buf_vec .+ d
+    # G[q,:] ← S G[q,:]
+    mul!(buf, S, symp_row)
+    symp_row .= buf
+    return state
+end
+
+"""
+    stellarrank(x::StellarState)
+
+Total degree of the core tensor, i.e. the stellar rank of the state.
+"""
+function stellarrank(x::StellarState)
+    n = nmodes(x)
+    rank = 0
+    @inbounds for I in CartesianIndices(x.core)
+        iszero(x.core[I]) && continue
+        rank = max(rank, sum(Tuple(I)) - n)
+    end
+    return rank
+end
+stellarrank(::GaussianState) = 0
+
+"""
+    GaussianState(x::StellarState)
+
+Return Gaussian state obtained from applying the Gaussian unitary part of `x`
+to a vacuum state.
+"""
+function GaussianState(x::StellarState)
+    iszero(stellarrank(x)) || throw(ArgumentError(RANK_ERROR))
+    return x.gaussian * vacuumstate(x.basis; ħ = x.ħ)
+end
+"""
+    StellarState(x::GaussianState)
+
+Rank-zero stellar state of a pure Gaussian state. The Williamson symplectic factor supplies
+`S` with `V = (ħ/2)SSᵀ` and the mean supplies `d`; the pair is the inverse of
+`GaussianState(::StellarState)`.
+"""
+function StellarState(x::GaussianState; atol::Real = 1e-8)
+    F = williamson(x)
+    all(v -> isapprox(v, x.ħ/2; atol = atol), F.spectrum) || throw(ArgumentError(STELLAR_PURITY_ERROR))
+    n = x.basis.nmodes
+    core = fill(one(ComplexF64), ntuple(_ -> 1, n))
+    return StellarState(core, GaussianUnitary(x.basis, x.mean, F.S; ħ = x.ħ))
+end
+
+purity(::StellarState) = 1.0
+entropy_vn(::StellarState) = 0.0
+
+"""
     isgaussian(x::GaussianState)
     isgaussian(x::GaussianUnitary)
     isgaussian(x::GaussianChannel)
@@ -440,4 +619,19 @@ function isgaussian(x::GaussianChannel; atol::R1 = 0, rtol::R2 = atol) where {R1
     @. form = noise + im*form - im*prod
     eigs = real(eigvals(form))
     return all(i -> ((i >= 0) || isapprox(i, 0.0; atol = atol, rtol = rtol)), eigs)
+end
+function isgaussian(x::StellarState; atol::R1 = 0, rtol::R2 = atol) where {R1<:Real,R2<:Real}
+    return iszero(stellarrank(x)) && isgaussian(x.gaussian; atol = atol, rtol = rtol)
+end
+
+
+function Base.summary(io::IO, x::Union{GaussianState,GaussianUnitary,GaussianChannel,StellarState})
+    printstyled(io, nameof(typeof(x)); color=:blue)
+    basis = x.basis
+    modenum = basis.nmodes
+    if isone(modenum)
+        print(io, " for $(modenum) mode.")
+    else
+        print(io, " for $(modenum) modes.")
+    end
 end

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -625,6 +625,21 @@ function _tensor(op1::GaussianUnitary{B1,D1,S1}, op2::GaussianUnitary{B2,D2,S2})
     return disp′′, symp′′
 end
 
+"""
+    inv(op::GaussianUnitary)
+
+Inverse in the group law `(d₁,S₁)*(d₂,S₂) = (S₁d₂+d₁, S₁S₂)`. The symplectic factor is
+inverted as `S⁻¹ = ΩSᵀΩᵀ`, which is exact and preserves `SΩSᵀ = Ω`.
+"""
+function Base.inv(op::GaussianUnitary)
+    Omega = symplecticform(op.basis)
+    symp = Omega * transpose(op.symplectic) * transpose(Omega)
+    disp = -(symp * op.disp)
+    disp′ = _promote_output_vector(typeof(op.disp), disp, length(disp))
+    symp′ = _promote_output_matrix(typeof(op.symplectic), symp, size(symp))
+    return GaussianUnitary(op.basis, disp′, symp′; ħ = op.ħ)
+end
+
 ##
 # Embedding Gaussian unitaries
 ##

--- a/src/wigner.jl
+++ b/src/wigner.jl
@@ -17,6 +17,64 @@ function wigner(state::GaussianState, x::T) where {T}
 end
 
 """
+    wigner(x::StellarState, xi)
+
+Wigner function of a stellar state. A Gaussian unitary acts on phase space by `ξ → Sξ + d`
+with `det S = 1`, so the Wigner function is the pullback of the core's Wigner function
+along `inv(x.gaussian)` with no Jacobian.
+"""
+function wigner(x::StellarState, xi)
+    basis = x.basis
+    n = basis.nmodes
+    length(xi) == 2*n || throw(ArgumentError(WIGNER_ERROR))
+    ginv = inv(x.gaussian)
+    y = ginv.symplectic * xi .+ ginv.disp
+    z = zeros(ComplexF64, n)
+    if basis isa QuadPairBasis
+        @inbounds for i in Base.OneTo(n)
+            z[i] = (y[2i-1] + im*y[2i]) / sqrt(2*x.ħ)
+        end
+    else
+        @inbounds for i in Base.OneTo(n)
+            z[i] = (y[i] + im*y[i+n]) / sqrt(2*x.ħ)
+        end
+    end
+    core = x.core
+    result = zero(ComplexF64)
+    @inbounds for K in CartesianIndices(core)
+        iszero(core[K]) && continue
+        for L in CartesianIndices(core)
+            iszero(core[L]) && continue
+            term = core[K] * conj(core[L])
+            for i in Base.OneTo(n)
+                term *= _fockwigner(K[i]-1, L[i]-1, z[i])
+            end
+            result += term
+        end
+    end
+    return real(result) / (2*x.ħ)^n
+end
+
+function _laguerre(n::Int, k::Int, t::Real)
+    n == 0 && return one(t)
+    Lm, L = one(t), one(t) + k - t
+    @inbounds for j in Base.OneTo(n-1)
+        Lm, L = L, ((2j + 1 + k - t) * L - (j + k) * Lm) / (j + 1)
+    end
+    return L
+end
+# Wigner transform of |m⟩⟨n|, normalized so that ∫ w_{nn} d²z = 1
+function _fockwigner(m::Int, n::Int, z::Number)
+    m < n && return conj(_fockwigner(n, m, z))
+    t = 4 * abs2(z)
+    r = 1.0
+    @inbounds for j in (n+1):m
+        r /= sqrt(j)
+    end
+    return (2/π) * (-1)^n * r * (2*conj(z))^(m-n) * exp(-t/2) * _laguerre(n, m-n, t)
+end
+
+"""
     wignerchar(state::GaussianState, xi)
 
 Compute the Wigner characteristic function of an N-mode Gaussian state at `xi`, a vector of size 2N.

--- a/test/test_stellar.jl
+++ b/test/test_stellar.jl
@@ -1,0 +1,272 @@
+@testitem "Stellar states" begin
+    using Gabs
+    using LinearAlgebra
+
+    nmodes = rand(1:5)
+    qpairbasis = QuadPairBasis(nmodes)
+    qblockbasis = QuadBlockBasis(nmodes)
+
+    @testset "fock states" begin
+        n = rand(1:3)
+        ns = rand(1:3, nmodes)
+        state_pair = fockstate(qpairbasis, n)
+        state_block = fockstate(qblockbasis, n)
+        @test state_pair isa StellarState && state_block isa StellarState
+        @test fockstate(Array, qpairbasis, n) isa StellarState
+        @test ndims(state_pair.core) == nmodes
+        @test size(state_pair.core) == Tuple(fill(n + 1, nmodes))
+        @test state_pair.core[CartesianIndex(size(state_pair.core))] == one(ComplexF64)
+        @test stellarrank(state_pair) == n * nmodes
+        @test stellarrank(fockstate(qpairbasis, ns)) == sum(ns)
+        @test iszero(state_pair.gaussian.disp)
+        @test state_pair.gaussian.symplectic == Matrix{Float64}(I, 2*nmodes, 2*nmodes)
+        @test state_pair.basis == qpairbasis && state_block.basis == qblockbasis
+        @test state_pair.ħ == 2 && state_block.ħ == 2
+        @test fockstate(qpairbasis, n, ħ = 1).ħ == 1
+        @test propertynames(state_pair) == (:basis, :core, :gaussian, :ħ)
+    end
+
+    @testset "gaussian unitary group" begin
+        op1, op2 = randunitary(qpairbasis), randunitary(qpairbasis)
+        prod = op1 * op2
+        @test prod isa GaussianUnitary
+        @test isapprox(prod.symplectic, op1.symplectic * op2.symplectic, atol = 1e-5)
+        @test isapprox(prod.disp, op1.symplectic * op2.disp + op1.disp, atol = 1e-5)
+        @test issymplectic(qpairbasis, prod.symplectic, atol = 1e-5)
+
+        v = randstate(qpairbasis)
+        @test isapprox((op1 * op2) * v, op1 * (op2 * v), atol = 1e-5)
+
+        for basis in [qpairbasis, qblockbasis]
+            op = randunitary(basis)
+            iden = op * inv(op)
+            @test issymplectic(basis, inv(op).symplectic, atol = 1e-5)
+            @test isapprox(iden.symplectic, Matrix{Float64}(I, 2*nmodes, 2*nmodes), atol = 1e-5)
+            @test isapprox(iden.disp, zeros(2*nmodes), atol = 1e-5)
+            @test isapprox((inv(op) * op).symplectic, Matrix{Float64}(I, 2*nmodes, 2*nmodes), atol = 1e-5)
+            @test isapprox((inv(op) * op).disp, zeros(2*nmodes), atol = 1e-5)
+            @test inv(op).ħ == op.ħ
+        end
+    end
+
+    @testset "stellar rank" begin
+        n = rand(1:3)
+        @test stellarrank(fockstate(qpairbasis, 0)) == 0
+        @test stellarrank(randstate(qpairbasis)) == 0
+        @test isgaussian(fockstate(qpairbasis, 0), atol = 1e-5)
+        @test !isgaussian(fockstate(qpairbasis, n), atol = 1e-5)
+
+        op = randunitary(qpairbasis)
+        x = fockstate(qpairbasis, n)
+        @test stellarrank(op * x) == stellarrank(x)
+    end
+
+    @testset "gaussian conversion" begin
+        for basis in [qpairbasis, qblockbasis]
+            st = randstate(basis, pure = true)
+            x = StellarState(st)
+            @test x isa StellarState
+            @test stellarrank(x) == 0
+            @test isapprox(GaussianState(x), st, rtol = 1e-5)
+            @test isapprox(x.gaussian.symplectic * transpose(x.gaussian.symplectic),
+                           (2/st.ħ) * st.covar, rtol = 1e-5)
+            @test x.ħ == st.ħ
+
+            sq = squeezedstate(basis, 0.5, π/4)
+            y = StellarState(sq)
+            @test isapprox(y.gaussian.symplectic, squeeze(basis, 0.5, π/4).symplectic, atol = 1e-10)
+            @test isapprox(GaussianState(y), sq, atol = 1e-10)
+            @test issymplectic(basis, y.gaussian.symplectic, atol = 1e-10)
+        end
+    end
+
+    @testset "unitary action" begin
+        n = rand(1:3)
+        for basis in [qpairbasis, qblockbasis]
+            x = fockstate(basis, n)
+            op = randunitary(basis)
+
+            y = op * x
+            @test y isa StellarState
+            @test y.core == x.core
+            @test isapprox(y.gaussian, op * x.gaussian, atol = 1e-5)
+
+            z = apply!(copy(x), op)
+            @test isapprox(z, y, atol = 1e-5)
+            @test stellarrank(z) == stellarrank(x)
+
+            single = typeof(basis)(1)
+            opsub = randunitary(single)
+            idx = rand(1:nmodes)
+            @test isapprox(apply!(copy(x), [idx], opsub),
+                           embed(basis, [idx], opsub) * x, atol = 1e-5)
+            @test isapprox(apply!(copy(x), idx, opsub),
+                           apply!(copy(x), [idx], opsub), atol = 1e-5)
+        end
+    end
+
+    @testset "tensor products" begin
+        basis1 = QuadPairBasis(1)
+        m, n = rand(1:3), rand(1:3)
+        x, y = fockstate(basis1, m), fockstate(basis1, n)
+
+        xy = tensor(x, y)
+        @test xy isa StellarState
+        @test xy == x ⊗ y
+        @test isapprox(xy, fockstate(QuadPairBasis(2), [m, n]), atol = 1e-10)
+        @test size(xy.core) == (m + 1, n + 1)
+        @test stellarrank(xy) == stellarrank(x) + stellarrank(y)
+        @test tensor(Array, Vector{Float64}, Matrix{Float64}, x, y) isa StellarState
+
+        z = fockstate(basis1, 0)
+        @test isapprox(x ⊗ y ⊗ z, fockstate(QuadPairBasis(3), [m, n, 0]), atol = 1e-10)
+    end
+
+    @testset "embed" begin
+        n = rand(1:3)
+        for basis in [QuadPairBasis(1), QuadBlockBasis(1)]
+            full_basis = basis ⊕ basis ⊕ basis
+            x = fockstate(basis, n)
+            vac = fockstate(basis, 0)
+
+            @test isapprox(embed(full_basis, 1, x), x ⊗ vac ⊗ vac, atol = 1e-10)
+            @test isapprox(embed(full_basis, 2, x), vac ⊗ x ⊗ vac, atol = 1e-10)
+            @test isapprox(embed(full_basis, 3, x), vac ⊗ vac ⊗ x, atol = 1e-10)
+            @test isapprox(embed(full_basis, [1, 3], x ⊗ x), x ⊗ vac ⊗ x, atol = 1e-10)
+            @test stellarrank(embed(full_basis, 2, x)) == stellarrank(x)
+
+            @test_throws AssertionError embed(full_basis, [1, 2], x)
+            @test_throws AssertionError embed(full_basis, [1, 2, 3, 4], x ⊗ x ⊗ x ⊗ x)
+        end
+    end
+
+    @testset "changebasis" begin
+        n = rand(1:3)
+        x_pair = randunitary(qpairbasis) * fockstate(qpairbasis, n)
+        x_block = changebasis(QuadBlockBasis, x_pair)
+
+        @test x_block isa StellarState
+        @test x_block.basis isa QuadBlockBasis
+        @test x_block.core == x_pair.core
+        @test stellarrank(x_block) == stellarrank(x_pair)
+        @test isapprox(changebasis(QuadPairBasis, x_block), x_pair, atol = 1e-10)
+        @test isapprox(changebasis(QuadBlockBasis, x_block), x_block, atol = 1e-10)
+        @test isapprox(changebasis(QuadPairBasis, x_pair), x_pair, atol = 1e-10)
+        @test x_block.ħ == x_pair.ħ
+
+        xi = randn(2*nmodes)
+        @test isapprox(wigner(x_pair, xi), wigner(x_block, changebasis(QuadBlockBasis, GaussianState(QuadPairBasis(nmodes), xi, Matrix{Float64}(I, 2*nmodes, 2*nmodes))).mean), atol = 1e-8)
+    end
+
+    @testset "photon addition and subtraction" begin
+        basis1 = QuadPairBasis(1)
+        r, theta = rand(Float64), 2π * rand(Float64)
+        alpha = rand(ComplexF64)
+
+        vac = fockstate(basis1, 0)
+        @test isapprox(addphoton(vac), fockstate(basis1, 1), atol = 1e-10)
+        @test isapprox(addphoton(addphoton(vac)), fockstate(basis1, 2), atol = 1e-10)
+        @test stellarrank(addphoton(vac)) == 1
+        @test isapprox(subtractphoton(addphoton(vac)), vac, atol = 1e-10)
+        @test length(subtractphoton(addphoton(vac)).core) == 1
+
+        sq = squeeze(basis1, r, theta) * vac
+        @test stellarrank(sq) == 0
+        @test stellarrank(addphoton(sq)) == 1
+        @test stellarrank(subtractphoton(sq)) == 1
+        @test isapprox(addphoton(sq).gaussian, sq.gaussian, atol = 1e-10)
+        @test isapprox(sum(abs2, addphoton(sq).core), 1.0, atol = 1e-10)
+        @test isapprox(sum(abs2, subtractphoton(sq).core), 1.0, atol = 1e-10)
+
+        coh = displace(basis1, alpha) * vac
+        sub = subtractphoton(coh)
+        @test stellarrank(sub) == 0
+        @test length(sub.core) == 1
+        @test isapprox(abs(sub.core[1]), 1.0, atol = 1e-10)
+        @test isapprox(sub.gaussian, coh.gaussian, atol = 1e-10)
+        @test isapprox(wigner(sub, [0.3, -0.7]), wigner(coh, [0.3, -0.7]), atol = 1e-10)
+        @test stellarrank(addphoton(coh)) == 1
+    end
+
+    @testset "wigner functions" begin
+        r, theta = rand(Float64), 2π * rand(Float64)
+        alpha = rand(ComplexF64)
+        xi = randn(2*nmodes)
+
+        for basis in [qpairbasis, qblockbasis]
+            op = randunitary(basis, passive = true)
+            @test isapprox(wigner(op * fockstate(basis, 0), xi),
+                           wigner(op * vacuumstate(basis), xi), rtol = 1e-6)
+
+            st = randstate(basis, pure = true)
+            @test isapprox(wigner(StellarState(st), st.mean), wigner(st, st.mean), rtol = 1e-6)
+
+            sq = squeezedstate(basis, 0.5, π/4)
+            @test isapprox(wigner(StellarState(sq), xi), wigner(sq, xi), rtol = 1e-6)
+        end
+
+        basis1 = QuadPairBasis(1)
+        @test isapprox(wigner(fockstate(basis1, 0), [0.0, 0.0]), 1/(2π), atol = 1e-10)
+        @test isapprox(wigner(fockstate(basis1, 1), [0.0, 0.0]), -1/(2π), atol = 1e-10)
+        @test wigner(fockstate(basis1, 1), [0.0, 0.0]) < 0
+        @test_throws ArgumentError wigner(fockstate(basis1, 1), zeros(4))
+    end
+
+    @testset "stellar function" begin
+        basis1 = QuadPairBasis(1)
+        z = rand(ComplexF64)
+        r = rand(Float64)
+        alpha = rand(ComplexF64)
+
+        @test isapprox(stellarfunction(fockstate(basis1, 0), z), 1.0 + 0.0im, atol = 1e-8)
+        @test isapprox(stellarfunction(fockstate(basis1, 1), z), z, atol = 1e-8)
+        @test isapprox(stellarfunction(fockstate(basis1, 2), z), z^2/sqrt(2), atol = 1e-8)
+        @test isapprox(stellarfunction(fockstate(basis1, 1), [z]),
+                       stellarfunction(fockstate(basis1, 1), z), atol = 1e-10)
+
+        coh = displace(basis1, alpha) * fockstate(basis1, 0)
+        @test isapprox(stellarfunction(coh, z), exp(-abs2(alpha)/2 + alpha*z), atol = 1e-8)
+
+        dis1 = displace(basis1, alpha) * fockstate(basis1, 1)
+        @test isapprox(stellarfunction(dis1, z), (z - conj(alpha))*exp(-abs2(alpha)/2 + alpha*z), atol = 1e-8)
+        @test isapprox(stellarfunction(dis1, conj(alpha)), 0.0 + 0.0im, atol = 1e-8)
+
+        sq = squeeze(basis1, r, 0.0) * fockstate(basis1, 0)
+        @test isapprox(stellarfunction(sq, z), exp(-tanh(r)*z^2/2)/sqrt(cosh(r)), atol = 1e-8)
+        @test isapprox(stellarfunction(sq, 0.0 + 0.0im), 1/sqrt(cosh(r)), atol = 1e-8)
+
+        @test isapprox(stellarfunction(addphoton(fockstate(basis1, 0)), z),
+                       stellarfunction(fockstate(basis1, 1), z), atol = 1e-8)
+
+        two = fockstate(basis1, 1) ⊗ fockstate(basis1, 1)
+        w = rand(ComplexF64)
+        @test isapprox(stellarfunction(two, [z, w]), z*w, atol = 1e-8)
+        @test_throws DimensionMismatch stellarfunction(fockstate(basis1, 1), [z, w])
+    end
+
+    @testset "random stellar states" begin
+        rank = rand(0:3)
+        for basis in [qpairbasis, qblockbasis]
+            x = randstellar(basis, rank)
+            @test x isa StellarState
+            @test randstellar(Array, basis, rank) isa StellarState
+            @test stellarrank(x) == rank
+            @test isapprox(sum(abs2, x.core), 1.0, atol = 1e-10)
+            @test issymplectic(basis, x.gaussian.symplectic, atol = 1e-5)
+            @test randstellar(basis, rank, ħ = 1).ħ == 1
+            @test randstellar(basis, rank, passive = true) isa StellarState
+            @test x.ħ == 2
+        end
+        @test isgaussian(randstellar(qpairbasis, 0), atol = 1e-5)
+        @test !isgaussian(randstellar(qpairbasis, 1), atol = 1e-5)
+    end
+
+    @testset "metrics" begin
+        rank = rand(0:3)
+        x = randstellar(qpairbasis, rank)
+        @test purity(x) == 1.0
+        @test entropy_vn(x) == 0.0
+        @test purity(fockstate(qpairbasis, 2)) == 1.0
+        @test entropy_vn(fockstate(qpairbasis, 2)) == 0.0
+    end
+end

--- a/test/test_throws.jl
+++ b/test/test_throws.jl
@@ -3,10 +3,22 @@
     using CairoMakie
 
     basis1 = QuadPairBasis(1)
+    basis2 = QuadPairBasis(2)
+
     @testset "type throws" begin
         @test_throws DimensionMismatch GaussianState(basis1, [1.0, 2.0, 3.0], [3.0 4.0; 5.0 6.0])
         @test_throws DimensionMismatch GaussianChannel(basis1, [1.0, 2.0, 3.0], [3.0 4.0; 5.0 6.0], [3.0 4.0; 5.0 6.0])
         @test_throws DimensionMismatch GaussianChannel(basis1, [1.0, 2.0], [3.0 4.0; 5.0 6.0], [3.0 4.0 4.0; 5.0 6.0 4.0])
+
+        iden = displace(basis1, 0.0 + 0.0im)
+        @test_throws DimensionMismatch StellarState(zeros(ComplexF64, 2, 2), iden)
+        @test_throws ArgumentError StellarState(zeros(ComplexF64, 3), iden)
+        @test_throws DimensionMismatch fockstate(basis1, [1, 2])
+    end
+
+    @testset "conversion throws" begin
+        @test_throws ArgumentError GaussianState(fockstate(basis1, 1))
+        @test_throws ArgumentError StellarState(thermalstate(basis1, 2))
     end
 
     @testset "action throws" begin
@@ -14,8 +26,27 @@
         ts = twosqueeze(2*basis1, rand(), rand())
         @test_throws DimensionMismatch ts * v
         @test_throws DimensionMismatch apply!(v, ts)
+
+        x = fockstate(basis1, 1)
+        ts = twosqueeze(basis2, rand(), rand())
+        @test_throws DimensionMismatch ts * x
+        @test_throws DimensionMismatch apply!(x, ts)
+        @test_throws DimensionMismatch ts * displace(basis1, 0.0 + 0.0im)
+        @test_throws ArgumentError apply!(x, [1, 2, 3], randunitary(basis1))
     end
 
+    @testset "partial trace throws" begin
+        x = fockstate(basis1, 1) ⊗ fockstate(basis1, 2)
+        @test_throws ArgumentError ptrace(x, 1)
+        @test_throws ArgumentError ptrace(x, [1])
+    end
+
+    @testset "photon subtraction throws" begin
+        @test_throws ArgumentError subtractphoton(fockstate(basis1, 0))
+        @test_throws ArgumentError addphoton(fockstate(basis2, 1), 3)
+        @test_throws ArgumentError subtractphoton(fockstate(basis2, 1), 0)
+    end
+    
     @testset "plot extension throws" begin
         ts = twosqueeze(2*basis1, rand(), rand())
         @test_throws ArgumentError Makie.heatmap(collect(-3.0:0.25:3.0), collect(-3.0:0.25:3.0), ts)
@@ -33,5 +64,13 @@
         @test_throws ArgumentError rs1 ⊗ rs2
         @test_throws ArgumentError ru1 ⊗ ru2
         @test_throws ArgumentError rc1 ⊗ rc2
+
+        x1, x2 = fockstate(basis1, 1, ħ = 1), fockstate(basis1, 1)
+        ru1, ru2 = randunitary(basis1, ħ = 1), randunitary(basis1)
+        @test_throws ArgumentError ru2 * x1
+        @test_throws ArgumentError apply!(x1, ru2)
+        @test_throws ArgumentError apply!(x2, ru1)
+        @test_throws ArgumentError ru1 * ru2
+        @test_throws ArgumentError x1 ⊗ x2
     end
 end


### PR DESCRIPTION
This PR has been sitting on my local desktop for quite a while; finally found the time to push it over the finish line. The `StellarState` data structure is based off this paper: https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.124.063605.

There's a number of things we can implement in future PRs:
- `StellarOperator` (polynomial in `(a†,a)` core rather than Fock core)  and `StellarEnsemble` (needed for `ptrace` and applications of `GaussianChannel`) types.
- Measurement interface for `StellarState` objects. I will have to think carefully about what can be done here. Presumably we can simulate PNR heralding here due to the Fock core which is rather exciting. The existing `Generaldyne` interface can also be used.

For all of these, it would good to document on the Gabs manual page. I don't know if any of these ideas are written in papers, but the concepts are straightforward enough that they can be hashed out with pen and paper. It would also be good to have a corresponding "Stellar Zoo" for well known stellar states, operators, ensembles, etc.

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>

